### PR TITLE
Add Travis continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: c++
+addons:
+  apt:
+    packages:
+      - default-java
+      - openmpi-bin
+      - libopenmpi-dev
+      - ruby
+      - gfortran
+      - python-dev
+install:
+  - cd build
+  - MUSCLE_CMAKE_OPTIONS="-DBUILD_PYTHON=ON -DBUILD_FORTRAN=ON -DBUILD_MATLAB=OFF"
+  - ./build.sh ~/muscle.install
+script:
+  - . ~/muscle.install/etc/muscle.profile
+  - make test


### PR DESCRIPTION
See https://travis-ci.org/blootsvoets/muscle2 for how the build looks. An administrator of psnc-apps would need to enable Travis to make this work. After the first build has completed, add the following badge just below the title in the README.md:

```
[![Build Status](https://travis-ci.org/psnc-apps/muscle2.svg?branch=master)](https://travis-ci.org/psnc-apps/muscle2)
```

Possible extension: get the MATLAB code to work with Octave, then `BUILD_MATLAB` can be set to `ON`.
