### PR TITLE
Modification for MUSCLE2 profiling for Allinea MAP interface

### DIFF
--- a/src/cpp/muscle2/cppmuscle.hpp
+++ b/src/cpp/muscle2/cppmuscle.hpp
@@ -50,6 +50,10 @@ public:
 
 	/** Initialize MUSCLE. Call before any other function, with pointers to the number of arguments and arguments. */
 	static muscle_error_t init(int* argc, char ***argv);
+
+	/** Initialize the perf counters */
+	static void reset_perf_counters();
+
 	/** Finalize MUSCLE. Call after any other function. */
 	static void finalize(void);
 

--- a/src/cpp/muscle2/muscle_perf.cpp
+++ b/src/cpp/muscle2/muscle_perf.cpp
@@ -13,3 +13,7 @@ bool MUSCLE_Perf_In_Call(struct timespec *start_time, muscle_perf_counter_t *id)
 const char * MUSCLE_Perf_Dump(void) {
 	return muscle::env::get_perf_string();
 }
+
+void MUSCLE_Perf_Reset_Counters() {
+	return muscle::env::reset_perf_counters();
+}

--- a/src/cpp/muscle2/muscle_perf.h
+++ b/src/cpp/muscle2/muscle_perf.h
@@ -44,6 +44,9 @@ int MUSCLE_Perf_Get_Counter(muscle_perf_counter_t id, uint64_t *value);
  * to id (e.g. MUSCLE_PERF_COUNTER_BARRIER_DURATION). If we aren't in any call, sets both start_time and id to NULL. */
 bool MUSCLE_Perf_In_Call(struct timespec *start_time, muscle_perf_counter_t *id);
 
+/* Initialize the counters to zero */
+void MUSCLE_Perf_Reset_Counters();
+
 #ifdef __cplusplus
 }
 #endif //__cplusplus


### PR DESCRIPTION
Bug found when testing Tube example from Sandbox - when MUSCLE2 send/receive calls performed from all MPI ranks with profiling enabled, the profiler is started on the non 0 MPI rank, but then MUSCLE2 returns. Thus incorrect timing information is produced for non master ranks.

Also added explicit initialisation of performance counters - to allow remote initialisation from Allinea MAP custom metric.
Before:
![image](https://cloud.githubusercontent.com/assets/2457047/23790458/05b9e528-0577-11e7-9a34-3c086851fdeb.png)


After:
![image](https://cloud.githubusercontent.com/assets/2457047/23790467/0fc4f288-0577-11e7-87c5-9cc674f64fdb.png)
